### PR TITLE
Fix error handler

### DIFF
--- a/src/make.js
+++ b/src/make.js
@@ -4,7 +4,9 @@ const fs = require('fs-extra')
 
 module.exports = make
 
-function make(filepath, { extendsStrategy, addComments }) {
+function make(filepath, options) {
+	const extendsStrategy = Object(options).extendsStrategy;
+	const addComments = Object(options).addComments;
 	try {
 		const tsconfig = require(filepath)
 


### PR DESCRIPTION
Catch block fails to add error information, because options variable is not defined.